### PR TITLE
Updates mix.exs with custom module, github orgization, and name

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,8 +1,8 @@
-defmodule NervesSystemBbb.MixProject do
+defmodule PurpleBBB.MixProject do
   use Mix.Project
 
-  @github_organization "nerves-project"
-  @app :nerves_system_bbb
+  @github_organization "ROARforGood"
+  @app :bbb_purple
   @source_url "https://github.com/#{@github_organization}/#{@app}"
   @version Path.join(__DIR__, "VERSION")
            |> File.read!()


### PR DESCRIPTION
These changes represent the minimal requirements for running `bbb_purple` as a custom nerves system. 

The `nerves_system_bbb` repo should be set as an upstream remote when used as part of the `mesh_gateway` app in the `purple_umbrella` repo. 