### PR TITLE
Lousy non-working overlay hack

### DIFF
--- a/fwup.conf
+++ b/fwup.conf
@@ -158,6 +158,8 @@ task complete {
 
         # Include provisioning instructions
         include("${NERVES_PROVISIONING}")
+        include("${NERVES_UPGRADE}")
+
 
         # Add in the generic Nerves metadata variables.
         uboot_setenv(uboot-env, "nerves_fw_active", "a")
@@ -231,13 +233,7 @@ task upgrade.a {
         raw_write(${ROOTFS_A_PART_OFFSET})
     }
 
-    on-finish {
-        # Include upgrade instructions
-        # TODO: how to handle a,b when it is a file being run?
-        include("${NERVES_UPGRADE}")
-        uboot_setenv(uboot-env, "uboot_overlay_addr3", "/lib/firmware/BB-ADC-00A0.dtbo")
-        
-
+    on-finish {        
         # Update firmware metadata
         uboot_setenv(uboot-env, "a.nerves_fw_application_part0_devpath", ${NERVES_FW_APPLICATION_PART0_DEVPATH})
         uboot_setenv(uboot-env, "a.nerves_fw_application_part0_fstype", ${NERVES_FW_APPLICATION_PART0_FSTYPE})
@@ -251,6 +247,9 @@ task upgrade.a {
         uboot_setenv(uboot-env, "a.nerves_fw_vcs_identifier", ${NERVES_FW_VCS_IDENTIFIER})
         uboot_setenv(uboot-env, "a.nerves_fw_misc", ${NERVES_FW_MISC})
         uboot_setenv(uboot-env, "a.nerves_fw_uuid", "\${FWUP_META_UUID}")
+
+        include("${NERVES_UPGRADE}")
+        uboot_setenv(uboot-env, "disable_uboot_overlay_addr3", "0")
 
         # Reset the validation status and boot to A
         # next time.
@@ -274,7 +273,6 @@ task upgrade.b {
 
     on-init {
         info("Upgrading partition B")
-        uboot_setenv(uboot-env, "uboot_overlay_addr3", "/lib/firmware/BB-ADC-00A0.dtbo")
 
         # Clear some firmware information just in case this update gets
         # interrupted midway.
@@ -294,9 +292,6 @@ task upgrade.b {
     }
 
     on-finish {
-        # Include upgrade instructions
-        # TODO: how to handle a,b when it is a file being run?
-        include("${NERVES_UPGRADE}")
         # Update firmware metadata
         uboot_setenv(uboot-env, "b.nerves_fw_application_part0_devpath", ${NERVES_FW_APPLICATION_PART0_DEVPATH})
         uboot_setenv(uboot-env, "b.nerves_fw_application_part0_fstype", ${NERVES_FW_APPLICATION_PART0_FSTYPE})
@@ -310,6 +305,9 @@ task upgrade.b {
         uboot_setenv(uboot-env, "b.nerves_fw_vcs_identifier", ${NERVES_FW_VCS_IDENTIFIER})
         uboot_setenv(uboot-env, "b.nerves_fw_misc", ${NERVES_FW_MISC})
         uboot_setenv(uboot-env, "b.nerves_fw_uuid", "\${FWUP_META_UUID}")
+
+        include("${NERVES_UPGRADE}")
+        uboot_setenv(uboot-env, "disable_uboot_overlay_addr3", "0")
 
         # Reset the validation status and boot to B next time.
         uboot_setenv(uboot-env, "nerves_fw_active", "b")
@@ -348,6 +346,7 @@ task provision {
     require-uboot-variable(uboot-env, "a.nerves_fw_architecture", "${NERVES_FW_ARCHITECTURE}")
     on-init {
         include("${NERVES_PROVISIONING}")
+        include("${NERVES_UPGRADE}")
     }
 }
 task provision.wrongplatform {

--- a/fwup_include/upgrade.conf
+++ b/fwup_include/upgrade.conf
@@ -1,0 +1,28 @@
+uboot_setenv(uboot-env, "disable_uboot_overlay_emmc", "1")
+uboot_setenv(uboot-env, "disable_uboot_overlay_video", "1")
+uboot_setenv(uboot-env, "disable_uboot_overlay_audio", "1")
+uboot_setenv(uboot-env, "disable_uboot_overlay_wireless", "1")
+uboot_setenv(uboot-env, "disable_uboot_overlay_adc", "0")
+uboot_unsetenv(uboot-env, "enable_uboot_cape_universal")
+uboot_setenv(uboot-env, "enable_uboot_cape_universala", "1")
+###
+###Debug: disable uboot autoload of Cape
+# ROAR These prevent the ADC from using addr1-3
+# ROAR we have no capes to auto-detect (yet). It would be good to have a ROARCape with a .dtbo
+uboot_setenv(uboot-env, "disable_uboot_overlay_addr0", "0")
+uboot_setenv(uboot-env, "disable_uboot_overlay_addr1", "0")
+uboot_setenv(uboot-env, "disable_uboot_overlay_addr2", "0")
+uboot_setenv(uboot-env, "disable_uboot_overlay_addr3", "0")
+###Additional custom capes
+### Gateway 2.0 Cape
+uboot_setenv(uboot-env, "uboot_overlay_addr0", "/lib/firmware/BB-SPIDEV1-00A0.dtbo")
+uboot_setenv(uboot-env, "uboot_overlay_addr1", "/lib/firmware/BB-I2C1-00A0.dtbo")
+uboot_setenv(uboot-env, "uboot_overlay_addr2", "/lib/firmware/i2c1-clock-frequency-100khz.dtbo")
+# ROAR why isn't the ADC auto-loaded?
+uboot_setenv(uboot-env, "uboot_overlay_addr3", "/lib/firmware/BB-ADC-00A0.dtbo")
+uboot_setenv(uboot-env, "uboot_overlay_addr4", "/lib/firmware/BB-UART1-00A0.dtbo")
+uboot_setenv(uboot-env, "uboot_overlay_addr5", "/lib/firmware/BB-UART2-00A0.dtbo")
+uboot_setenv(uboot-env, "uboot_overlay_addr6", "/lib/firmware/BB-UART4-00A0.dtbo")
+uboot_setenv(uboot-env, "uboot_overlay_addr7", "/lib/firmware/BB-UART5-00A0.dtbo")
+
+# ROAR, to know what was loaded: `ls -l /sys/firmware/devicetree/base/chosen/overlays/`


### PR DESCRIPTION
It sets the u-boot env but the overlays defined in the env are not loaded.